### PR TITLE
Update README with new repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Azure Email Communication Service - Rust
 
+
+## I've change repo to https://github.com/preedep/azure-ecs-rs and https://crates.io/crates/azure-ecs-rs instead of
+
+
+
 This is a simple example of how to send an email using Azure Communication Service with REST API and SMTP.
 
 It is developed according to this document.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the repository and crate links for the Azure Email Communication Service in Rust.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R7): Updated the repository and crate links to `https://github.com/preedep/azure-ecs-rs` and `https://crates.io/crates/azure-ecs-rs`.The README.md file now includes updated links to the new GitHub repository and crates.io page for the Azure Email Communication Service. This change ensures users can access the most current version and resources.